### PR TITLE
Add metadata_proxy_num_threads config option

### DIFF
--- a/neutron/tests/unit/agent/metadata/test_namespace_proxy.py
+++ b/neutron/tests/unit/agent/metadata/test_namespace_proxy.py
@@ -259,7 +259,8 @@ class TestProxyDaemon(base.BaseTestCase):
                                           'router_id')
                 pd.run()
                 Server.assert_has_calls([
-                    mock.call('neutron-network-metadata-proxy'),
+                    mock.call('neutron-network-metadata-proxy',
+                              num_threads=None),
                     mock.call().start(mock.ANY, 9697),
                     mock.call().wait()]
                 )
@@ -274,6 +275,7 @@ class TestProxyDaemon(base.BaseTestCase):
                         cfg.CONF.metadata_port = 9697
                         cfg.CONF.pid_file = 'pidfile'
                         cfg.CONF.daemonize = True
+                        cfg.CONF.metadata_proxy_num_threads = 25
                         utils_cfg.CONF.log_opt_values.return_value = None
                         ns_proxy.main()
 
@@ -284,7 +286,8 @@ class TestProxyDaemon(base.BaseTestCase):
                                       network_id=None,
                                       user=mock.ANY,
                                       group=mock.ANY,
-                                      watch_log=mock.ANY),
+                                      watch_log=mock.ANY,
+                                      proxy_threads=25),
                             mock.call().start()]
                         )
 
@@ -298,6 +301,7 @@ class TestProxyDaemon(base.BaseTestCase):
                         cfg.CONF.metadata_port = 9697
                         cfg.CONF.pid_file = 'pidfile'
                         cfg.CONF.daemonize = False
+                        cfg.CONF.metadata_proxy_num_threads = 50
                         utils_cfg.CONF.log_opt_values.return_value = None
                         ns_proxy.main()
 
@@ -308,6 +312,7 @@ class TestProxyDaemon(base.BaseTestCase):
                                       network_id=None,
                                       user=mock.ANY,
                                       group=mock.ANY,
-                                      watch_log=mock.ANY),
+                                      watch_log=mock.ANY,
+                                      proxy_threads=50),
                             mock.call().run()]
                         )


### PR DESCRIPTION
This patch adds a neutron configuration option metadata_proxy_num_threads
with a default of 1000. This sets the maximum number of wsgi threads used
for the neutron metadata proxy. The neutron wide wsgi thread setting was
changed[1] to 100 which can lead to metadata proxy performance issues.
For a full discussion on the change to 100 see the dev list email[2].

[1] https://review.openstack.org/#/c/306187/
[2]http://lists.openstack.org/pipermail/openstack-dev/2015-December/082717.html