### PR TITLE
Make ns proxy use existing option for num_threads

### DIFF
--- a/neutron/agent/metadata/driver.py
+++ b/neutron/agent/metadata/driver.py
@@ -103,7 +103,8 @@ class MetadataDriver(object):
                          '--state_path=%s' % conf.state_path,
                          '--metadata_port=%s' % port,
                          '--metadata_proxy_user=%s' % user,
-                         '--metadata_proxy_group=%s' % group]
+                         '--metadata_proxy_group=%s' % group,
+                         '--config-file=/etc/neutron/neutron.conf']
             proxy_cmd.extend(config.get_log_args(
                 conf, 'neutron-ns-metadata-proxy-%s.log' % uuid,
                 metadata_proxy_watch_log=watch_log))

--- a/neutron/agent/metadata/namespace_proxy.py
+++ b/neutron/agent/metadata/namespace_proxy.py
@@ -115,21 +115,19 @@ class NetworkMetadataProxyHandler(object):
 
 class ProxyDaemon(daemon.Daemon):
     def __init__(self, pidfile, port, network_id=None, router_id=None,
-                 user=None, group=None, watch_log=True, proxy_threads=None):
+                 user=None, group=None, watch_log=True):
         uuid = network_id or router_id
         super(ProxyDaemon, self).__init__(pidfile, uuid=uuid, user=user,
                                          group=group, watch_log=watch_log)
         self.network_id = network_id
         self.router_id = router_id
         self.port = port
-        self.proxy_threads = proxy_threads
 
     def run(self):
         handler = NetworkMetadataProxyHandler(
             self.network_id,
             self.router_id)
-        proxy = wsgi.Server('neutron-network-metadata-proxy',
-                            num_threads=self.proxy_threads)
+        proxy = wsgi.Server('neutron-network-metadata-proxy')
         proxy.start(handler, self.port)
 
         # Drop privileges after port bind
@@ -170,10 +168,6 @@ def main():
                     help=_("Watch file log. Log watch should be disabled when "
                            "metadata_proxy_user/group has no read/write "
                            "permissions on metadata proxy log file.")),
-        cfg.IntOpt('metadata_proxy_num_threads',
-                   default=1000,
-                   help=_("Number of threads for the metadata_proxy wsgi "
-                          "pool. Default is 1000.")),
     ]
 
     cfg.CONF.register_cli_opts(opts)
@@ -188,8 +182,7 @@ def main():
                         router_id=cfg.CONF.router_id,
                         user=cfg.CONF.metadata_proxy_user,
                         group=cfg.CONF.metadata_proxy_group,
-                        watch_log=cfg.CONF.metadata_proxy_watch_log,
-                        proxy_threads=cfg.CONF.metadata_proxy_num_threads)
+                        watch_log=cfg.CONF.metadata_proxy_watch_log)
 
     if cfg.CONF.daemonize:
         proxy.start()

--- a/neutron/tests/unit/agent/metadata/test_namespace_proxy.py
+++ b/neutron/tests/unit/agent/metadata/test_namespace_proxy.py
@@ -259,8 +259,7 @@ class TestProxyDaemon(base.BaseTestCase):
                                           'router_id')
                 pd.run()
                 Server.assert_has_calls([
-                    mock.call('neutron-network-metadata-proxy',
-                              num_threads=None),
+                    mock.call('neutron-network-metadata-proxy'),
                     mock.call().start(mock.ANY, 9697),
                     mock.call().wait()]
                 )
@@ -275,7 +274,6 @@ class TestProxyDaemon(base.BaseTestCase):
                         cfg.CONF.metadata_port = 9697
                         cfg.CONF.pid_file = 'pidfile'
                         cfg.CONF.daemonize = True
-                        cfg.CONF.metadata_proxy_num_threads = 25
                         utils_cfg.CONF.log_opt_values.return_value = None
                         ns_proxy.main()
 
@@ -286,8 +284,7 @@ class TestProxyDaemon(base.BaseTestCase):
                                       network_id=None,
                                       user=mock.ANY,
                                       group=mock.ANY,
-                                      watch_log=mock.ANY,
-                                      proxy_threads=25),
+                                      watch_log=mock.ANY),
                             mock.call().start()]
                         )
 
@@ -301,7 +298,6 @@ class TestProxyDaemon(base.BaseTestCase):
                         cfg.CONF.metadata_port = 9697
                         cfg.CONF.pid_file = 'pidfile'
                         cfg.CONF.daemonize = False
-                        cfg.CONF.metadata_proxy_num_threads = 50
                         utils_cfg.CONF.log_opt_values.return_value = None
                         ns_proxy.main()
 
@@ -312,7 +308,6 @@ class TestProxyDaemon(base.BaseTestCase):
                                       network_id=None,
                                       user=mock.ANY,
                                       group=mock.ANY,
-                                      watch_log=mock.ANY,
-                                      proxy_threads=50),
+                                      watch_log=mock.ANY),
                             mock.call().run()]
                         )


### PR DESCRIPTION
This reverts 0e75032 in favor of using the existing option that was intended to be used to set the wsgi pool size[1]. The problem was neutron-ns-metadata-proxy being called without passing the `--config-file option` so `CONF.wsgi_default_pool_size` in wsgi.Server was always unset[2], causing it to fall back to the olso default, even though wsgi_default_pool_size was set in neutron.conf.

Passing the config file when calling neutron-ns-metadata-proxy properly sets the option and I have verified wsgi.Server is picking up the value from neutron.conf.

[1] https://github.com/openstack/neutron/blob/mitaka-eol/releasenotes/notes/config-wsgi-pool-size-a4c06753b79fee6d.yaml
[2] https://github.com/openstack/neutron/blob/mitaka-eol/neutron/wsgi.py#L119